### PR TITLE
Fix goal number sizing bug.

### DIFF
--- a/partials/section-goals.php
+++ b/partials/section-goals.php
@@ -85,6 +85,12 @@
               border-radius: 100%;
               border: 4px solid white;
               box-shadow: 0px 4px 10px -2px black;
+
+              width: 100px;
+              height: 100px;
+              display: flex;
+              justify-content: center;
+              align-content: center;
             }
 
             @media(min-width: 1140px) {


### PR DESCRIPTION
Fixes a small CSS integration issue between where the First "1" goal number on the UBC site is displaying in an oblong fashion inconsistent with the rest of the goal numbers.

See screenshot for context:

<img width="914" alt="Screen Shot 2021-09-13 at 13 20 09" src="https://user-images.githubusercontent.com/10760868/133129779-a8fc9e7e-f41b-4aab-973a-16c375168814.png">

Tested this by injecting the CSS into the page https://isp.ubc.ca/implementation/the-action-plan/ using my web inspector, so I believe this should fix the issue. 
