### PR TITLE
Fix line height bug for download link on mobile.

### DIFF
--- a/template-action-plan.php
+++ b/template-action-plan.php
@@ -16,6 +16,7 @@ get_header(); // Loads the header.php template.
     margin-bottom: 32px!important;
     font-size: 40px; 
     text-decoration: none!important;
+    line-height: 1em;
   }
 
   .strategic-plan:hover, .strategic-plan:focus {


### PR DESCRIPTION
Fixes a responsive issue where the download link on the strategic action plan page wasn't displaying properly.

<img width="314" alt="Screen Shot 2021-09-13 at 13 59 06" src="https://user-images.githubusercontent.com/10760868/133133515-374eff4b-6ac2-432e-9a4d-755f40bbd6b5.png">
